### PR TITLE
Extend editor API

### DIFF
--- a/demo-edit-es-module/module/editor.d.ts
+++ b/demo-edit-es-module/module/editor.d.ts
@@ -9,14 +9,21 @@ interface EditArgs {
 }
 
 interface EditApi {
-    focus() : void
-    saySomething() : string
-    setText(text: string) : void
-    getText() : string
+    focus(): void
+
+    saySomething(): string
+
+    setText(text: string): void
+
+    getText(): string
+
+    setFontFamily(fontFamily: string): void
+
+    setFontSize(fontSize: number): void
 }
 
 interface EditView extends EditApi {
-    dispose() : void
+    dispose(): void
 }
 
-export function newEditor(args: EditArgs) : Promise<EditView>
+export function newEditor(args: EditArgs): Promise<EditView>

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/EditorModule.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/EditorModule.java
@@ -51,6 +51,18 @@ public class EditorModule implements Editor_d_ts {
     return JSString.valueOf(line);
   }
 
+  @Override
+  public void setFontFamily(JSString fontFamily) {
+    EditorComponent editor = demoEdit.editor();
+    editor.changeFont(fontFamily.stringValue(), editor.getFontVirtualSize());
+  }
+
+  @Override
+  public void setFontSize(int fontSize) {
+    EditorComponent editor = demoEdit.editor();
+    editor.changeFont(editor.getFontFamily(), fontSize);
+  }
+
   static void onWebGlError() {
     JsHelper.consoleInfo("FATAL: WebGL is not enabled in the browser");
   }

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/Editor_d_ts.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/Editor_d_ts.java
@@ -16,6 +16,9 @@ public interface Editor_d_ts extends JSObject {
   JSString saySomething();
   void setText(JSString t);
   JSString getText();
+  void setFontFamily(JSString fontFamily);
+  void setFontSize(int fontSize);
+
 
   interface EditArguments extends JSObject {
     @JSProperty JSString getContainerId();

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/DemoEdit0.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/DemoEdit0.java
@@ -129,19 +129,19 @@ public class DemoEdit0 extends Scene {
   }
 
   private void setSegoeUI() {
-    editor.changeFont(Fonts.SegoeUI, editor.getFontISize());
+    editor.changeFont(Fonts.SegoeUI, editor.getFontVirtualSize());
   }
 
   private void setVerdana() {
-    editor.changeFont(Fonts.Verdana, editor.getFontISize());
+    editor.changeFont(Fonts.Verdana, editor.getFontVirtualSize());
   }
 
   private void setJetBrainsMono() {
-    editor.changeFont(Fonts.JetBrainsMono, editor.getFontISize());
+    editor.changeFont(Fonts.JetBrainsMono, editor.getFontVirtualSize());
   }
 
   private void setConsolas() {
-    editor.changeFont(Fonts.Consolas, editor.getFontISize());
+    editor.changeFont(Fonts.Consolas, editor.getFontVirtualSize());
   }
 
   class EditInput implements InputListener {

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/EditorComponent.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/EditorComponent.java
@@ -108,7 +108,6 @@ public class EditorComponent implements EditApi, Disposable {
   }
 
   void setPos(V2i pos, V2i size, double dpr) {
-    System.out.println("dpr = " + dpr);
     compPos.set(pos);
     compSize.set(size);
     devicePR = dpr;
@@ -264,7 +263,6 @@ public class EditorComponent implements EditApi, Disposable {
 
 
   public void changeFont(String name, int virtualSize) {
-    System.out.println("changeFont: virtualSize = " + virtualSize);
     if (devicePR != 0) {
       doChangeFont(name, virtualSize);
     }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/EditorComponent.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/EditorComponent.java
@@ -108,6 +108,7 @@ public class EditorComponent implements EditApi, Disposable {
   }
 
   void setPos(V2i pos, V2i size, double dpr) {
+    System.out.println("dpr = " + dpr);
     compPos.set(pos);
     compSize.set(size);
     devicePR = dpr;
@@ -124,7 +125,8 @@ public class EditorComponent implements EditApi, Disposable {
     caret.setWidth(Numbers.iRnd(Caret.defaultWidth * devicePR));
 
     // Should be called if dpr changed
-    setFont(fontFamilyName, fontVirtualSize);
+
+    doChangeFont(fontFamilyName, fontVirtualSize);
 
     updateLineNumbersFont();
 
@@ -219,8 +221,8 @@ public class EditorComponent implements EditApi, Disposable {
     return fontFamilyName;
   }
 
-  private void setFont(String name, int size) {
-    setFonts(name, size);
+  private void setFont(String name, int pixelSize) {
+    setFonts(name, pixelSize);
 
     int fontLineHeight = font.lineHeight();
     lineHeight = Numbers.iRnd(fontLineHeight * EditorConst.LINE_HEIGHT);
@@ -229,7 +231,7 @@ public class EditorComponent implements EditApi, Disposable {
     renderingCanvas = Disposable.assign(
         renderingCanvas, g.createCanvas(EditorConst.TEXTURE_WIDTH, lineHeight));
 
-    Debug.consoleInfo("Set editor font to: " + name + " " + size
+    Debug.consoleInfo("Set editor font to: " + name + " " + pixelSize
         + ", ascent+descent = " + fontLineHeight
         + ", lineHeight = " + lineHeight
         + ", caretHeight = " + caret.height());
@@ -251,21 +253,28 @@ public class EditorComponent implements EditApi, Disposable {
     font = fonts[CodeElement.fontIndex(false, false)];
   }
 
+
+
   public void changeFont(String name, int virtualSize) {
+    System.out.println("changeFont: virtualSize = " + virtualSize);
     if (devicePR != 0) {
-      int newPixelFontSize = Numbers.iRnd(virtualSize * devicePR);
-      int oldPixelFontSize = font == null ? 0 : font.iSize;
-      if (newPixelFontSize != oldPixelFontSize || !Objects.equals(name, fontFamilyName)) {
-        lineNumbers.dispose();
-        invalidateFont();
-        setFont(name, newPixelFontSize);
-        afterFontChanged();
-        updateLineNumbersFont();
-      }
+      doChangeFont(name, virtualSize);
     }
     fontVirtualSize = virtualSize;
     fontFamilyName = name;
     api.window.repaint();
+  }
+
+  private void doChangeFont(String name, int virtualSize) {
+    int newPixelFontSize = Numbers.iRnd(virtualSize * devicePR);
+    int oldPixelFontSize = font == null ? 0 : font.iSize;
+    if (newPixelFontSize != oldPixelFontSize || !Objects.equals(name, fontFamilyName)) {
+      lineNumbers.dispose();
+      invalidateFont();
+      setFont(name, newPixelFontSize);
+      afterFontChanged();
+      updateLineNumbersFont();
+    }
   }
 
   private void afterFontChanged() {


### PR DESCRIPTION
## Description

Added an option to change font family and font size through the editor API.

Fixes #13 

## Example

```javascript
const fonts = ["Helvetica", "Verdana", "Courier New", "Segoe UI", "Consolas", "JetBrains Mono"]

const fontSize = 35;

function openEditor(divName, isFocused, setter, text, fontFamily) {
    newEditor({containerId: divName, workerUrl: "worker.js"}).then(
        editorApi => {
            setter(editorApi);
            if (isFocused) editorApi.focus();
            if (text) editorApi.setText(text);
            editorApi.setFontFamily(fontFamily);
            editorApi.setFontSize(fontSize);
            console.log(`Editor started on ${divName}: ${editorApi.saySomething()}`)
        }, error => console.error(error));
}
```

Use `editorApi.setFontFamily()` and `editorApi.setFontSize()`.

## How to test

### Manual tests

Tested on @eqimd training project with two editors, on the browser version and on the JVM version.