### PR TITLE
Byte to Char usage throught the project

### DIFF
--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/EditorModule.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/EditorModule.java
@@ -1,6 +1,7 @@
 package org.sudu.experiments;
 
-import org.sudu.experiments.demo.*;
+import org.sudu.experiments.demo.DemoEdit0;
+import org.sudu.experiments.demo.EditorComponent;
 import org.sudu.experiments.js.*;
 import org.teavm.jso.core.JSObjects;
 import org.teavm.jso.core.JSString;
@@ -36,13 +37,19 @@ public class EditorModule implements Editor_d_ts {
 
   @Override
   public void setText(JSString t) {
-    demoEdit.editor().setText(TextEncoder.toUtf8(t));
+    int l = t.getLength();
+    char[] buffer = new char[l];
+    for (int i = 0; i < l; ++i) {
+      char codeAt = (char) t.charCodeAt(i);
+      buffer[i] = codeAt;
+    }
+    demoEdit.editor().setText(buffer);
   }
 
   @Override
   public JSString getText() {
-    byte[] bytes = demoEdit.document().getBytes();
-    return TextDecoder.fromUtf8(bytes);
+    char[] chars = demoEdit.document().getChars();
+    return JSString.valueOf(new String(chars));
   }
 
   @Override

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/EditorModule.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/EditorModule.java
@@ -37,19 +37,14 @@ public class EditorModule implements Editor_d_ts {
 
   @Override
   public void setText(JSString t) {
-    int l = t.getLength();
-    char[] buffer = new char[l];
-    for (int i = 0; i < l; ++i) {
-      char codeAt = (char) t.charCodeAt(i);
-      buffer[i] = codeAt;
-    }
+    char[] buffer = TextEncoder.toCharArray(t);
     demoEdit.editor().setText(buffer);
   }
 
   @Override
   public JSString getText() {
     char[] chars = demoEdit.document().getChars();
-    return JSString.valueOf(new String(chars));
+    return TextDecoder.fromCharArray(chars);
   }
 
   @Override

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/DemoEdit0.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/DemoEdit0.java
@@ -37,7 +37,7 @@ public class DemoEdit0 extends Scene {
     this.setCursor = SetCursor.wrap(api.window);
 
     editor = new EditorComponent(api);
-    editor.setText(StartFile.getBytes());
+    editor.setText(StartFile.getChars());
 
     api.input.addListener(new EditInput());
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/Document.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/Document.java
@@ -267,9 +267,9 @@ public class Document {
     return sb.toString();
   }
 
-  public byte[] getBytes() {
+  public char[] getChars() {
     String documentText = makeString();
-    return documentText.getBytes(StandardCharsets.UTF_8);
+    return documentText.toCharArray();
   }
 
   public int[] getIntervals() {

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/EditApi.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/EditApi.java
@@ -3,8 +3,8 @@ package org.sudu.experiments.demo;
 import org.sudu.experiments.Disposable;
 
 interface EditApi {
-  void setText(byte[] urf8bytes);
-  byte[] getText();
+  void setText(char[] charArray);
+  char[] getText();
 
   boolean selectAll();
 

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/EditorComponent.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/EditorComponent.java
@@ -943,7 +943,7 @@ public class EditorComponent implements EditApi, Disposable {
 
   void reparse() {
     parsingTimeStart = System.currentTimeMillis();
-    api.window.sendToWorker(this::onFileParsed, JavaParser.PARSE_BYTES_JAVA, document.getBytes());
+    api.window.sendToWorker(this::onFileParsed, JavaParser.PARSE_BYTES_JAVA, document.getChars());
   }
 
   public void parseViewport() {
@@ -956,7 +956,7 @@ public class EditorComponent implements EditApi, Disposable {
 
   private void parseViewport(int type) {
     if (type == FileParser.JAVA_FILE)
-      api.window.sendToWorker(this::onVpParsed, JavaParser.PARSE_BYTES_JAVA_VIEWPORT, document.getBytes(), getViewport(), document.getIntervals() );
+      api.window.sendToWorker(this::onVpParsed, JavaParser.PARSE_BYTES_JAVA_VIEWPORT, document.getChars(), getViewport(), document.getIntervals() );
   }
 
   private int[] getViewport() {
@@ -971,7 +971,7 @@ public class EditorComponent implements EditApi, Disposable {
 
   public void parseFullFile() {
     parsingTimeStart = System.currentTimeMillis();
-    api.window.sendToWorker(this::onFileParsed, JavaParser.PARSE_BYTES_JAVA, document.getBytes());
+    api.window.sendToWorker(this::onFileParsed, JavaParser.PARSE_BYTES_JAVA, document.getChars());
   }
 
   public void iterativeParsing() {
@@ -1138,14 +1138,14 @@ public class EditorComponent implements EditApi, Disposable {
   /* API */
 
   @Override
-  public void setText(byte[] utf8bytes) {
+  public void setText(char[] charArray) {
     parsingTimeStart = System.currentTimeMillis();
-    api.window.sendToWorker(this::onFileParsed, JavaParser.PARSE_BYTES_JAVA, utf8bytes);
+    api.window.sendToWorker(this::onFileParsed, JavaParser.PARSE_BYTES_JAVA, charArray);
   }
 
   @Override
-  public byte[] getText() {
-    return document.getBytes();
+  public char[] getText() {
+    return document.getChars();
   }
 
   @Override

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/StartFile.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/StartFile.java
@@ -37,7 +37,7 @@ public interface StartFile {
       }
       """;
 
-  static byte[] getBytes() {
-    return START_CODE_JAVA.getBytes(StandardCharsets.UTF_8);
+  static char[] getChars() {
+    return START_CODE_JAVA.toCharArray();
   }
 }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/worker/EditorWorker.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/worker/EditorWorker.java
@@ -27,11 +27,11 @@ public class EditorWorker {
       case TestJobs.withChars -> TestJobs.withChars(array(a, 0).chars(), result);
       case TestJobs.withBytes -> TestJobs.withBytes(array(a, 0).bytes(), result);
       case TestJobs.withInts -> TestJobs.withInts(array(a, 0).ints(), result);
-      case LineParser.PARSE_LINES -> LineParser.parseBytes(array(a, 0).bytes(), result);
-      case KeywordParser.PARSE_KEYWORDS -> KeywordParser.parseBytes(array(a, 0).bytes(), result);
-      case JavaParser.PARSE_BYTES_JAVA -> JavaParser.parseBytes(array(a, 0).bytes(), result);
-      case JavaParser.PARSE_BYTES_JAVA_VIEWPORT -> JavaParser.parseViewport(array(a, 0).bytes(), array(a, 1).ints(), array(a, 2).ints(), result);
-      case JavaStructureParser.PARSE_STRUCTURE_JAVA -> JavaStructureParser.parseBytes(array(a, 0).bytes(), result);
+      case LineParser.PARSE_LINES -> LineParser.parseChars(array(a, 0).chars(), result);
+      case KeywordParser.PARSE_KEYWORDS -> KeywordParser.parseChars(array(a, 0).chars(), result);
+      case JavaParser.PARSE_BYTES_JAVA -> JavaParser.parseChars(array(a, 0).chars(), result);
+      case JavaParser.PARSE_BYTES_JAVA_VIEWPORT -> JavaParser.parseViewport(array(a, 0).chars(), array(a, 1).ints(), array(a, 2).ints(), result);
+      case JavaStructureParser.PARSE_STRUCTURE_JAVA -> JavaStructureParser.parseChars(array(a, 0).chars(), result);
     }
   }
 

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/worker/JavaLexerFirstLines.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/worker/JavaLexerFirstLines.java
@@ -17,18 +17,17 @@ public class JavaLexerFirstLines {
 
   public static final String LEXER_FIRST_LINES = "asyncJavaLexerFirstLines.parseFirstLines";
 
-  public static void parseFirstLines(byte[] bytes, int[] lines, Consumer<Object[]> result) {
+  public static void parseFirstLines(char[] chars, int[] lines, Consumer<Object[]> result) {
     ArrayList<Object> list = new ArrayList<>();
-    parseFirstLines(bytes, lines, list);
+    parseFirstLines(chars, lines, list);
     ArrayOp.sendArrayList(list, result);
   }
 
-  private static void parseFirstLines(byte[] bytes, int[] lines, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8).replace("\r", "");
+  private static void parseFirstLines(char[] chars, int[] lines, List<Object> result) {
+    String source = new String(chars);
     JavaFirstLinesLexer parser = new JavaFirstLinesLexer();
     int numOfLines = lines[0];
     int[] ints = parser.parse(source, numOfLines);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/worker/JavaParser.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/worker/JavaParser.java
@@ -3,18 +3,16 @@ package org.sudu.experiments.demo.worker;
 import org.sudu.experiments.parser.java.parser.JavaFullParser;
 import org.sudu.experiments.parser.java.parser.JavaViewportIntervalsParser;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class JavaParser {
 
   public static final String PARSE_BYTES_JAVA = "JavaParser.parseBytes";
 
-  public static void parseBytes(byte[] bytes, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8).replace("\r", "");
+  public static void parseChars(char[] chars, List<Object> result) {
+    String source = new String(chars);
 
     int[] ints = new JavaFullParser().parse(source);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
     result.add(new int[]{FileParser.JAVA_FILE});
@@ -22,11 +20,10 @@ public class JavaParser {
 
   public static final String PARSE_BYTES_JAVA_VIEWPORT = "JavaParser.parseViewport";
 
-  public static void parseViewport(byte[] bytes, int[] viewport, int[] intervals, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8).replace("\r", "");
+  public static void parseViewport(char[] chars, int[] viewport, int[] intervals, List<Object> result) {
+    String source = new String(chars);
 
     int[] ints = new JavaViewportIntervalsParser().parseViewport(source, viewport, intervals);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/worker/JavaStructureParser.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/worker/JavaStructureParser.java
@@ -2,18 +2,17 @@ package org.sudu.experiments.demo.worker;
 
 import org.sudu.experiments.parser.java.parser.JavaFullStructureParser;
 
-import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 public class JavaStructureParser {
 
   public static final String PARSE_STRUCTURE_JAVA = "JavaStructureParser.parseBytes";
 
-  public static void parseBytes(byte[] bytes, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8).replace("\r", "");
+  public static void parseChars(char[] chars, List<Object> result) {
+    String source = new String(chars);
 
     int[] ints = new JavaFullStructureParser().parse(source);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/worker/KeywordParser.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/worker/KeywordParser.java
@@ -5,11 +5,7 @@ import org.sudu.experiments.demo.CodeElement;
 import org.sudu.experiments.demo.CodeLine;
 import org.sudu.experiments.demo.Document;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.StringTokenizer;
+import java.util.*;
 
 public class KeywordParser {
 
@@ -21,11 +17,10 @@ public class KeywordParser {
 
   public static final String PARSE_KEYWORDS = "KeywordParser.parseBytes";
 
-  public static void parseBytes(byte[] bytes, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8);
+  public static void parseChars(char[] chars, List<Object> result) {
+    String source = new String(chars);
     KeywordParser parser = new KeywordParser();
     int[] ints = parser.parseIntArray(source);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/demo/worker/LineParser.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/demo/worker/LineParser.java
@@ -1,16 +1,12 @@
 package org.sudu.experiments.demo.worker;
 
 import org.sudu.experiments.Debug;
-import org.sudu.experiments.FileHandle;
-import org.sudu.experiments.demo.CodeElement;
-import org.sudu.experiments.demo.CodeLine;
-import org.sudu.experiments.demo.Document;
 import org.sudu.experiments.math.ArrayOp;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
 
@@ -22,27 +18,25 @@ public class LineParser {
 
   public static final String PARSE_LINES = "LineParser.parseBytes";
 
-  public static void parseBytes(byte[] bytes, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8);
+  public static void parseChars(char[] chars, List<Object> result) {
+    String source = new String(chars);
     LineParser parser = new LineParser();
     int[] ints = parser.parseIntArray(source, Integer.MAX_VALUE);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
   }
 
-  public static void parseFirstLines(byte[] bytes, int[] lines, Consumer<Object[]> result) {
+  public static void parseFirstLines(char[] chars, int[] lines, Consumer<Object[]> result) {
     ArrayList<Object> list = new ArrayList<>();
-    parseFirstLines(bytes, lines, list);
+    parseFirstLines(chars, lines, list);
     ArrayOp.sendArrayList(list, result);
   }
 
-  private static void parseFirstLines(byte[] bytes, int[] lines, List<Object> result) {
-    String source = new String(bytes, StandardCharsets.UTF_8);
+  private static void parseFirstLines(char[] chars, int[] lines, List<Object> result) {
+    String source = new String(chars);
     LineParser parser = new LineParser();
     int numOfLines = lines[0];
     int[] ints = parser.parseIntArray(source, numOfLines);
-    char[] chars = source.toCharArray();
     result.add(ints);
     result.add(chars);
   }

--- a/graphics-js/src/main/java/org/sudu/experiments/js/TextDecoder.java
+++ b/graphics-js/src/main/java/org/sudu/experiments/js/TextDecoder.java
@@ -3,13 +3,23 @@ package org.sudu.experiments.js;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.JSObject;
 import org.teavm.jso.core.JSString;
+import org.teavm.jso.typedarrays.Uint16Array;
 import org.teavm.jso.typedarrays.Uint8Array;
 
 public abstract class TextDecoder implements JSObject {
   @JSBody(script = "return new TextDecoder();")
   public static native TextDecoder create();
 
+  @JSBody(params = "label", script = "return new TextDecoder(label);")
+  public static native TextDecoder create(String label);
+
+  public abstract JSString decode(Uint16Array array);
+
   public abstract JSString decode(Uint8Array array);
+
+  public static JSString fromCharArray(char[] data) {
+    return create("utf-16").decode(JsMemoryAccess.bufferView(data));
+  }
 
   public static JSString fromUtf8(byte[] data) {
     return create().decode(JsMemoryAccess.uInt8View(data));

--- a/graphics-js/src/main/java/org/sudu/experiments/js/TextEncoder.java
+++ b/graphics-js/src/main/java/org/sudu/experiments/js/TextEncoder.java
@@ -3,15 +3,21 @@ package org.sudu.experiments.js;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.JSObject;
 import org.teavm.jso.core.JSString;
-import org.teavm.jso.typedarrays.Uint8Array;
+import org.teavm.jso.typedarrays.Uint16Array;
 
 public abstract class TextEncoder implements JSObject {
   @JSBody(script = "return new TextEncoder();")
   public static native TextEncoder create();
 
-  public abstract Uint8Array encode(JSString string);
-
-  public static byte[] toUtf8(JSString string) {
-    return JsMemoryAccess.toByteArray(create().encode(string));
+  public static char[] toCharArray(JSString t) {
+    int l = t.getLength();
+    char[] buffer = new char[l];
+    for (int i = 0; i < l; ++i) {
+      char codeAt = (char) t.charCodeAt(i);
+      buffer[i] = codeAt;
+    }
+    return buffer;
   }
+
+  public abstract Uint16Array encode(JSString string);
 }


### PR DESCRIPTION
byte[] was used previously to work with text (extraction, parsing, etc) that created overhead throught the whole project. Move to char[] was performed.