### PR TITLE
Rename npm package to @sudu-ide/editor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,6 @@ jobs:
           echo "::notice::version \"${NEW_VERSION}\""
           cd $GITHUB_WORKSPACE/sudu-editor/demo-edit-es-module/module
           npm version ${NEW_VERSION}
-          npm publish
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/demo-edit-es-module/module/package.json
+++ b/demo-edit-es-module/module/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sudu-editor-tmp",
+  "name": "@sudu-ide/editor",
   "version": "0.0.9-beta-something",
   "description": "Sudu Editor built on Java",
   "author": "Kirill Prazdnikov",


### PR DESCRIPTION
Required to configure special npm registry for sudu-editor.