### PR TITLE
Fixes in tree view keyboard navigation

### DIFF
--- a/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
@@ -431,17 +431,17 @@ public class TreeView extends ScrollContent implements Focusable {
 
   private boolean moveUp() {
     int idx = selectedIndex() - 1;
-    int index = idx >= 0 ? idx : model.lines.length - 1;
-    selectedLine = model.lines[index];
-    checkScroll(index);
+    if(idx < 0) return false;
+    selectedLine = model.lines[idx];
+    checkScroll(idx);
     return true;
   }
 
   private boolean moveDown() {
     int idx = selectedIndex() + 1;
-    int index = idx > 0 && idx < model.lines.length ? idx : 0;
-    selectedLine = model.lines[index];
-    checkScroll(index);
+    if(idx >= model.lines.length) return false;
+    selectedLine = model.lines[idx];
+    checkScroll(idx);
     return true;
   }
 

--- a/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
@@ -379,7 +379,7 @@ public class TreeView extends ScrollContent implements Focusable {
       case KeyCode.ARROW_DOWN -> moveDown();
       case KeyCode.ARROW_UP -> moveUp();
       case KeyCode.ARROW_RIGHT -> openIfClosedElseMoveDown();
-      case KeyCode.ARROW_LEFT -> closeIfOpened();
+      case KeyCode.ARROW_LEFT -> closeIfOpenedElseMoveToParent();
       case KeyCode.ENTER -> enterSelected();
       default -> false;
     };
@@ -394,11 +394,14 @@ public class TreeView extends ScrollContent implements Focusable {
     return true;
   }
 
-  private boolean closeIfOpened() {
-    if (selectedLine != null && selectedLine.isOpened()
-        && selectedLine.onClickArrow != null)
-      selectedLine.onClickArrow.run();
-    return true;
+  private boolean closeIfOpenedElseMoveToParent() {
+    if (selectedLine != null && selectedLine.isOpened()){
+      if(selectedLine.onClickArrow != null)
+        selectedLine.onClickArrow.run();
+      return true;
+    } else {
+      return moveToParent();
+    }
   }
 
   private boolean openIfClosedElseMoveDown() {
@@ -409,6 +412,21 @@ public class TreeView extends ScrollContent implements Focusable {
     } else {
       return moveDown();
     }
+  }
+
+  private boolean moveToParent() {
+    int idx = selectedIndex();
+    if(idx < 0) return false;
+    int parentDepth = model.lines[idx].depth - 1;
+    if(parentDepth < 0) return false;
+    for(idx--; idx >= 0; idx--){
+      if(model.lines[idx].depth == parentDepth) {
+        selectedLine = model.lines[idx];
+        checkScroll(idx);
+        return true;
+      }
+    }
+    return false;
   }
 
   private boolean moveUp() {


### PR DESCRIPTION
* Remove circular up/down keyboard navigation in tree view
* Jump to parent node on left key if it is already collapsed