### PR TITLE
Support `setFontSize` API in folder diff view

### DIFF
--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsFolderDiff0.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsFolderDiff0.java
@@ -80,7 +80,8 @@ public class JsFolderDiff0 implements JsFolderDiff {
   public void setTheme(JSString themeStr) {
     var theme = ThemeControl.resolveTheme(themeStr.stringValue());
     if (theme != null) {
-      if(overrideFontSize > 0) theme = theme.withFontSize(overrideFontSize);
+      if (overrideFontSize > 0)
+        theme = theme.withFontSize(overrideFontSize);
       scene.applyTheme(theme);
     } else {
       Debug.consoleInfo("unknown theme: " + theme);

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsFolderDiff0.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsFolderDiff0.java
@@ -1,8 +1,10 @@
 package org.sudu.experiments.diff;
 
+import org.sudu.experiments.Debug;
 import org.sudu.experiments.JsLauncher;
 
 import org.sudu.experiments.WebWindow;
+import org.sudu.experiments.editor.ThemeControl;
 import org.sudu.experiments.esm.*;
 import org.sudu.experiments.js.*;
 import org.teavm.jso.core.JSBoolean;
@@ -12,6 +14,7 @@ public class JsFolderDiff0 implements JsFolderDiff {
 
   public final WebWindow window;
   protected FolderDiffScene scene;
+  private float overrideFontSize = 0;
 
   protected JsFolderDiff0(WebWindow window, EditArgs args) {
     this.window = window;
@@ -65,14 +68,23 @@ public class JsFolderDiff0 implements JsFolderDiff {
 //    diff.setFontFamily(fontFamily.stringValue());
   }
 
+
   @Override
   public void setFontSize(float fontSize) {
-//    diff.setFontSize(fontSize);
+    overrideFontSize = fontSize;
+    var theme = scene.w.getTheme().withFontSize(fontSize);
+    scene.applyTheme(theme);
   }
 
   @Override
-  public void setTheme(JSString theme) {
-    scene.w.setTheme(theme.stringValue());
+  public void setTheme(JSString themeStr) {
+    var theme = ThemeControl.resolveTheme(themeStr.stringValue());
+    if (theme != null) {
+      if(overrideFontSize > 0) theme = theme.withFontSize(overrideFontSize);
+      scene.applyTheme(theme);
+    } else {
+      Debug.consoleInfo("unknown theme: " + theme);
+    }
   }
 
   public static Promise<JsFolderDiff> newDiff(EditArgs arguments) {

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsRemoteFolderDiff0.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsRemoteFolderDiff0.java
@@ -1,6 +1,8 @@
 package org.sudu.experiments.diff;
 
 import org.sudu.experiments.*;
+import org.sudu.experiments.editor.ThemeControl;
+import org.sudu.experiments.editor.ui.colors.EditorColorScheme;
 import org.sudu.experiments.esm.EditArgs;
 import org.sudu.experiments.esm.JsFolderDiff;
 import org.sudu.experiments.js.*;
@@ -14,6 +16,8 @@ public class JsRemoteFolderDiff0 implements JsRemoteFolderDiff {
 
   public final WebWindow window;
   protected RemoteFolderDiffScene folderDiff;
+
+  private float overrideFontSize = 0;
 
   protected JsRemoteFolderDiff0(WebWindow window, EditArgs args) {
     this.window = window;
@@ -57,12 +61,20 @@ public class JsRemoteFolderDiff0 implements JsRemoteFolderDiff {
 
   @Override
   public void setFontSize(float fontSize) {
-//    diff.setFontSize(fontSize);
+    overrideFontSize = fontSize;
+    var theme = folderDiff.getTheme().withFontSize(fontSize);
+    folderDiff.applyTheme(theme);
   }
 
   @Override
-  public void setTheme(JSString theme) {
-    folderDiff.setTheme(theme.stringValue());
+  public void setTheme(JSString themeStr) {
+    var theme = ThemeControl.resolveTheme(themeStr.stringValue());
+    if (theme != null) {
+      if(overrideFontSize > 0) theme = theme.withFontSize(overrideFontSize);
+      folderDiff.applyTheme(theme);
+    } else {
+      Debug.consoleInfo("unknown theme: " + theme);
+    }
   }
 
   @Override

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsRemoteFolderDiff0.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/JsRemoteFolderDiff0.java
@@ -70,7 +70,8 @@ public class JsRemoteFolderDiff0 implements JsRemoteFolderDiff {
   public void setTheme(JSString themeStr) {
     var theme = ThemeControl.resolveTheme(themeStr.stringValue());
     if (theme != null) {
-      if(overrideFontSize > 0) theme = theme.withFontSize(overrideFontSize);
+      if (overrideFontSize > 0)
+        theme = theme.withFontSize(overrideFontSize);
       folderDiff.applyTheme(theme);
     } else {
       Debug.consoleInfo("unknown theme: " + theme);

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/RemoteFolderDiffScene.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/RemoteFolderDiffScene.java
@@ -28,6 +28,10 @@ public class RemoteFolderDiffScene extends WindowScene implements ThemeControl {
     w.applyTheme(t);
   }
 
+  public EditorColorScheme getTheme() {
+    return w.getTheme();
+  }
+
   @Override
   public void onResize(V2i newSize, float newDpr) {
     boolean init = windowManager.uiContext.dpr == 0;

--- a/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/RemoteFolderDiffWindow.java
+++ b/demo-edit-es-module/src/main/java/org/sudu/experiments/diff/RemoteFolderDiffWindow.java
@@ -53,6 +53,8 @@ public class RemoteFolderDiffWindow extends ToolWindow0 {
   private final Consumer<String>[] openFileMap = new Consumer[MAP_SIZE];
   private int keyCnt = 0;
 
+  private final ArrayList<ToolWindow0> windows = new ArrayList<>();
+
   public RemoteFolderDiffWindow(
       EditorColorScheme theme,
       WindowManager wm,
@@ -91,6 +93,9 @@ public class RemoteFolderDiffWindow extends ToolWindow0 {
     super.applyTheme(theme);
     window.setTheme(theme.dialogItem);
     rootView.applyTheme(theme);
+    for (ToolWindow0 window : windows) {
+      window.applyTheme(theme);
+    }
   }
 
   protected void dispose() {
@@ -206,6 +211,7 @@ public class RemoteFolderDiffWindow extends ToolWindow0 {
         var opposite = getOppositeFile(node);
         if (opposite != null) {
           var window = new FileDiffWindow(windowManager, theme, fonts);
+          addWindow(window);
           openFileMap[keyCnt] = (source) -> window.open(source, node.name(), left);
           sendOpenFile(node, left);
           openFileMap[keyCnt] = (source) -> window.open(source, opposite.name(), !left);
@@ -213,6 +219,7 @@ public class RemoteFolderDiffWindow extends ToolWindow0 {
           window.window.maximize();
         } else {
           var window = new EditorWindow(windowManager, theme, fonts);
+          addWindow(window);
           openFileMap[keyCnt] = (source) -> window.open(source, node.name());
           sendOpenFile(node, left);
           window.maximize();
@@ -277,6 +284,11 @@ public class RemoteFolderDiffWindow extends ToolWindow0 {
         else return getOpposite(subNode, deque);
       }
     };
+  }
+
+  private void addWindow(ToolWindow0 window) {
+    windows.add(window);
+    window.setOnClose(() -> windows.remove(window));
   }
 
   private void sendOpenFile(RemoteFileNode node, boolean left) {

--- a/demo-edit/src/main/java/org/sudu/experiments/diff/FileDiffWindow.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/diff/FileDiffWindow.java
@@ -57,6 +57,7 @@ public class FileDiffWindow extends ToolWindow0
 
   @Override
   public void applyTheme(EditorColorScheme theme) {
+    super.applyTheme(theme);
     window.setTheme(theme.dialogItem);
     rootView.applyTheme(theme);
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/diff/FolderDiffScene.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/diff/FolderDiffScene.java
@@ -7,7 +7,7 @@ import org.sudu.experiments.editor.ui.colors.EditorColorScheme;
 import org.sudu.experiments.fonts.Fonts;
 import org.sudu.experiments.math.V2i;
 
-public class FolderDiffScene extends WindowScene {
+public class FolderDiffScene extends WindowScene implements ThemeControl {
 
   FolderDiffWindow w;
 
@@ -31,4 +31,13 @@ public class FolderDiffScene extends WindowScene {
   }
 
   public void setReadonly(boolean flag) {}
+
+  @Override
+  public void applyTheme(EditorColorScheme theme) {
+    w.applyTheme(theme);
+  }
+
+  public EditorColorScheme getTheme() {
+    return w.getTheme();
+  }
 }

--- a/demo-edit/src/main/java/org/sudu/experiments/editor/EditorComponent.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/editor/EditorComponent.java
@@ -208,7 +208,7 @@ public class EditorComponent extends View implements
     caret.setColor(theme.editor.cursor);
     vScroll.setColor(theme.editor.scrollBarLine, theme.editor.scrollBarBg);
     hScroll.setColor(theme.editor.scrollBarLine, theme.editor.scrollBarBg);
-    if(fontVirtualSize != theme.editorFont.size || !fontFamilyName.equals(theme.editorFont.familyName)) {
+    if (!theme.editorFont.equals(fontFamilyName, fontVirtualSize)) {
       changeFont(theme.editorFont.familyName, theme.editorFont.size);
     }
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/editor/EditorComponent.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/editor/EditorComponent.java
@@ -208,6 +208,9 @@ public class EditorComponent extends View implements
     caret.setColor(theme.editor.cursor);
     vScroll.setColor(theme.editor.scrollBarLine, theme.editor.scrollBarBg);
     hScroll.setColor(theme.editor.scrollBarLine, theme.editor.scrollBarBg);
+    if(fontVirtualSize != theme.editorFont.size || !fontFamilyName.equals(theme.editorFont.familyName)) {
+      changeFont(theme.editorFont.familyName, theme.editorFont.size);
+    }
   }
 
   void toggleXOffset() {

--- a/demo-edit/src/main/java/org/sudu/experiments/editor/EditorWindow.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/editor/EditorWindow.java
@@ -56,6 +56,7 @@ public class EditorWindow extends ToolWindow0 implements InputListeners.KeyHandl
 
   @Override
   public void applyTheme(EditorColorScheme theme) {
+    super.applyTheme(theme);
     window.setTheme(theme.dialogItem);
     ui.setTheme(theme);
     editor.setTheme(theme);

--- a/demo-edit/src/main/java/org/sudu/experiments/editor/ui/colors/EditorColorScheme.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/editor/ui/colors/EditorColorScheme.java
@@ -75,7 +75,7 @@ public class EditorColorScheme {
         new UiFont(defaultFont, defaultFontSize),
         new UiFont(Fonts.codicon, defaultFontSize),
         new UiFont(EditorConst.FONT, EditorConst.DEFAULT_FONT_SIZE)
-        );
+    );
   }
 
   private EditorColorScheme(
@@ -108,8 +108,13 @@ public class EditorColorScheme {
   }
 
   public EditorColorScheme withFontSize(float fontSize) {
-    return new EditorColorScheme(editor, fileTreeView, codeElement, lineNumber, dialogItem, diff,
-        popupMenuFont.withSize(fontSize), usagesFont.withSize(fontSize), fileViewFont.withSize(fontSize), fileViewIcons.withSize(fontSize), editorFont.withSize(fontSize));
+    return new EditorColorScheme(editor, fileTreeView, codeElement,
+        lineNumber, dialogItem, diff,
+        popupMenuFont.withSize(fontSize),
+        usagesFont.withSize(fontSize),
+        fileViewFont.withSize(fontSize),
+        fileViewIcons.withSize(fontSize),
+        editorFont.withSize(fontSize));
   }
 
   public CodeLineColorScheme editorCodeLineScheme() {

--- a/demo-edit/src/main/java/org/sudu/experiments/editor/ui/colors/EditorColorScheme.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/editor/ui/colors/EditorColorScheme.java
@@ -1,5 +1,6 @@
 package org.sudu.experiments.editor.ui.colors;
 
+import org.sudu.experiments.editor.EditorConst;
 import org.sudu.experiments.fonts.Fonts;
 import org.sudu.experiments.math.Color;
 import org.sudu.experiments.parser.ParserConstants;
@@ -13,10 +14,16 @@ public class EditorColorScheme {
   public final LineNumbersColors lineNumber;
   public final DiffColors diff;
 
-  public final UiFont popupMenuFont = new UiFont(Fonts.SegoeUI, 17);
-  public final UiFont usagesFont = new UiFont(Fonts.Consolas, 15);
-  public final UiFont fileViewFont = new UiFont(Fonts.SegoeUI, 15);
-  public final UiFont fileViewIcons = new UiFont(Fonts.codicon, 15);
+  private static final float defaultFontSize = 15;
+  private static final float defaultMenuFontSize = 17;
+  private static final String defaultFont = Fonts.SegoeUI;
+  private static final String defaultUsagesFont = Fonts.Consolas;
+
+  public final UiFont popupMenuFont;
+  public final UiFont usagesFont;
+  public final UiFont fileViewFont;
+  public final UiFont fileViewIcons;
+  public final UiFont editorFont;
 
   public Color error() {
     return codeElement[ParserConstants.TokenTypes.ERROR].colorF;
@@ -62,6 +69,27 @@ public class EditorColorScheme {
       DialogItemColors dialogItem,
       DiffColors diff
   ) {
+    this(editor, fileTreeView, codeElement, lineNumber, dialogItem, diff,
+        new UiFont(defaultFont, defaultMenuFontSize),
+        new UiFont(defaultUsagesFont, defaultFontSize),
+        new UiFont(defaultFont, defaultFontSize),
+        new UiFont(Fonts.codicon, defaultFontSize),
+        new UiFont(EditorConst.FONT, EditorConst.DEFAULT_FONT_SIZE)
+        );
+  }
+
+  private EditorColorScheme(
+      EditorColors editor, FileTreeViewTheme fileTreeView,
+      CodeElementColor[] codeElement,
+      LineNumbersColors lineNumber,
+      DialogItemColors dialogItem,
+      DiffColors diff,
+      UiFont popupMenuFont,
+      UiFont usagesFont,
+      UiFont fileViewFont,
+      UiFont fileViewIcons,
+      UiFont editorFont
+  ) {
     this.editor = editor;
     this.fileTreeView = fileTreeView;
     this.codeElement = codeElement;
@@ -71,6 +99,17 @@ public class EditorColorScheme {
     }
     this.dialogItem = dialogItem;
     this.diff = diff;
+
+    this.popupMenuFont = popupMenuFont;
+    this.usagesFont = usagesFont;
+    this.fileViewFont = fileViewFont;
+    this.fileViewIcons = fileViewIcons;
+    this.editorFont = editorFont;
+  }
+
+  public EditorColorScheme withFontSize(float fontSize) {
+    return new EditorColorScheme(editor, fileTreeView, codeElement, lineNumber, dialogItem, diff,
+        popupMenuFont.withSize(fontSize), usagesFont.withSize(fontSize), fileViewFont.withSize(fontSize), fileViewIcons.withSize(fontSize), editorFont.withSize(fontSize));
   }
 
   public CodeLineColorScheme editorCodeLineScheme() {

--- a/demo-edit/src/main/java/org/sudu/experiments/editor/ui/colors/EditorColorScheme.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/editor/ui/colors/EditorColorScheme.java
@@ -22,6 +22,7 @@ public class EditorColorScheme {
   public final UiFont popupMenuFont;
   public final UiFont usagesFont;
   public final UiFont fileViewFont;
+  public final UiFont treeViewFont;
   public final UiFont fileViewIcons;
   public final UiFont editorFont;
 
@@ -74,7 +75,8 @@ public class EditorColorScheme {
         new UiFont(defaultUsagesFont, defaultFontSize),
         new UiFont(defaultFont, defaultFontSize),
         new UiFont(Fonts.codicon, defaultFontSize),
-        new UiFont(EditorConst.FONT, EditorConst.DEFAULT_FONT_SIZE)
+        new UiFont(EditorConst.FONT, EditorConst.DEFAULT_FONT_SIZE),
+        new UiFont(defaultFont, defaultFontSize)
     );
   }
 
@@ -88,7 +90,8 @@ public class EditorColorScheme {
       UiFont usagesFont,
       UiFont fileViewFont,
       UiFont fileViewIcons,
-      UiFont editorFont
+      UiFont editorFont,
+      UiFont treeViewFont
   ) {
     this.editor = editor;
     this.fileTreeView = fileTreeView;
@@ -105,6 +108,7 @@ public class EditorColorScheme {
     this.fileViewFont = fileViewFont;
     this.fileViewIcons = fileViewIcons;
     this.editorFont = editorFont;
+    this.treeViewFont = treeViewFont;
   }
 
   public EditorColorScheme withFontSize(float fontSize) {
@@ -114,7 +118,8 @@ public class EditorColorScheme {
         usagesFont.withSize(fontSize),
         fileViewFont.withSize(fontSize),
         fileViewIcons.withSize(fontSize),
-        editorFont.withSize(fontSize));
+        editorFont.withSize(fontSize),
+        treeViewFont.withSize(fontSize));
   }
 
   public CodeLineColorScheme editorCodeLineScheme() {

--- a/demo-edit/src/main/java/org/sudu/experiments/ui/ToolWindow0.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/ToolWindow0.java
@@ -14,6 +14,7 @@ public abstract class ToolWindow0 implements ThemeControl {
   protected final WindowManager windowManager;
   protected final Supplier<String[]> fonts;
   protected EditorColorScheme theme;
+  protected Runnable onClose;
 
   protected ToolWindow0(
       WindowManager windowManager,
@@ -23,6 +24,14 @@ public abstract class ToolWindow0 implements ThemeControl {
     this.windowManager = windowManager;
     this.theme = theme;
     this.fonts = fonts;
+  }
+
+  public void setOnClose(Runnable onClose) {
+    this.onClose = onClose;
+  }
+
+  public EditorColorScheme getTheme() {
+    return theme;
   }
 
   public void applyTheme(EditorColorScheme theme) {
@@ -50,7 +59,10 @@ public abstract class ToolWindow0 implements ThemeControl {
 
   protected abstract void dispose();
 
-  private void destroyWindow(Window window) {
+  protected void destroyWindow(Window window) {
+    if (onClose != null) {
+      onClose.run();
+    }
     windowManager.removeWindow(window);
     window.dispose();
     dispose();

--- a/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
@@ -147,7 +147,7 @@ public class TreeView extends ScrollContent implements Focusable {
     boolean sameFont1 = Objects.equals(uiFont, colors.fileViewFont);
     boolean sameFont2 = Objects.equals(uiIcons, colors.fileViewIcons);
     if (!sameFont1 || !sameFont2) {
-      uiFont = colors.fileViewFont;
+      uiFont = colors.treeViewFont;
       uiIcons = colors.fileViewIcons;
       if (dpr != 0)
         changeFont();

--- a/demo-edit/src/main/java/org/sudu/experiments/ui/UiFont.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/UiFont.java
@@ -41,6 +41,10 @@ public class UiFont {
         && Objects.equals(familyName, uiFont.familyName);
   }
 
+  public boolean equals(String family, float newSize) {
+    return size == newSize && familyName.equals(family);
+  }
+
   public UiFont withSize(float fontSize) {
     return new UiFont(familyName, fontSize, weightRegular, weightBold);
   }

--- a/demo-edit/src/main/java/org/sudu/experiments/ui/UiFont.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/UiFont.java
@@ -40,4 +40,8 @@ public class UiFont {
         && weightBold == uiFont.weightBold
         && Objects.equals(familyName, uiFont.familyName);
   }
+
+  public UiFont withSize(float fontSize) {
+    return new UiFont(familyName, fontSize, weightRegular, weightBold);
+  }
 }


### PR DESCRIPTION
* Add `editorFont` into `EditorColorScheme` and use it in `EditorComponent`
* Add utils for copying `EditorColorScheme` with modified fonts
* Store font size override in `setFontSize` Js API implementations and modify applied theme with these params before passing it through views hierarchy