### PR TITLE
Workaround to fix sticky hover in tree view

### DIFF
--- a/demo-edit/src/main/java/org/sudu/experiments/diff/FolderDiffRootView.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/diff/FolderDiffRootView.java
@@ -93,15 +93,17 @@ class FolderDiffRootView extends DiffRootView implements ThemeControl {
 
   @Override
   public boolean onMouseMove(MouseEvent event, SetCursor setCursor) {
-    if (this.left.hitTest(event.position))
-      this.left.onMouseMove(event, setCursor);
-    else
-      this.left.onMouseLeave();
+    if (left.hitTest(event.position)) {
+      left.onMouseMove(event, setCursor);
+    } else {
+      left.onMouseLeave();
+    }
 
-    if (this.right.hitTest(event.position))
-      this.right.onMouseMove(event, setCursor);
-    else
-      this.right.onMouseLeave();
+    if (right.hitTest(event.position)) {
+      right.onMouseMove(event, setCursor);
+    } else {
+      right.onMouseLeave();
+    }
     return true;
   }
 }

--- a/demo-edit/src/main/java/org/sudu/experiments/diff/FolderDiffRootView.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/diff/FolderDiffRootView.java
@@ -4,8 +4,10 @@ import org.sudu.experiments.Subscribers;
 import org.sudu.experiments.editor.ThemeControl;
 import org.sudu.experiments.editor.ui.colors.EditorColorScheme;
 import org.sudu.experiments.editor.worker.diff.DiffInfo;
+import org.sudu.experiments.input.MouseEvent;
 import org.sudu.experiments.ui.FileTreeDiffRef;
 import org.sudu.experiments.ui.FileTreeView;
+import org.sudu.experiments.ui.SetCursor;
 import org.sudu.experiments.ui.UiContext;
 import org.sudu.experiments.ui.window.ScrollView;
 
@@ -87,5 +89,19 @@ class FolderDiffRootView extends DiffRootView implements ThemeControl {
 
   public interface SelectionListener {
     void accept(Selection selection);
+  }
+
+  @Override
+  public boolean onMouseMove(MouseEvent event, SetCursor setCursor) {
+    if (this.left.hitTest(event.position))
+      this.left.onMouseMove(event, setCursor);
+    else
+      this.left.onMouseLeave();
+
+    if (this.right.hitTest(event.position))
+      this.right.onMouseMove(event, setCursor);
+    else
+      this.right.onMouseLeave();
+    return true;
   }
 }

--- a/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
+++ b/demo-edit/src/main/java/org/sudu/experiments/ui/TreeView.java
@@ -193,7 +193,7 @@ public class TreeView extends ScrollContent implements Focusable {
   }
 
   public int selectedIndex() {
-   return selectedIndex;
+    return selectedIndex;
   }
 
   @Override
@@ -338,6 +338,10 @@ public class TreeView extends ScrollContent implements Focusable {
     return viewY / lineHeight;
   }
 
+  public void onMouseLeave() {
+    hoveredIndex = -1;
+  }
+
   @Override
   public boolean onMouseMove(MouseEvent event, SetCursor setCursor) {
     int line = getLineNumber(event);
@@ -468,8 +472,8 @@ public class TreeView extends ScrollContent implements Focusable {
 
   private boolean closeIfOpenedElseMoveToParent() {
     TreeNode selectedLine = selectedLine();
-    if (selectedLine != null && selectedLine.isOpened()){
-      if(selectedLine.onClickArrow != null)
+    if (selectedLine != null && selectedLine.isOpened()) {
+      if (selectedLine.onClickArrow != null)
         selectedLine.onClickArrow.run();
       return true;
     } else {
@@ -506,7 +510,7 @@ public class TreeView extends ScrollContent implements Focusable {
 
   private boolean moveUp() {
     int idx = selectedIndex - 1;
-    if(idx < 0) return false;
+    if (idx < 0) return false;
     selectedIndex = idx;
     checkScroll(idx);
     onSelectedLineChanged(idx);
@@ -515,7 +519,7 @@ public class TreeView extends ScrollContent implements Focusable {
 
   private boolean moveDown() {
     int idx = selectedIndex + 1;
-    if(idx >= model.lines.length) return false;
+    if (idx >= model.lines.length) return false;
     selectedIndex = idx;
     checkScroll(idx);
     onSelectedLineChanged(idx);


### PR DESCRIPTION
Force call `onMouseLeave` in `TreeView` on any mouse move in `FolderDiffRootView` that is outside the given `TreeView`.