### PR TITLE
Add typesVersions to package.json

### DIFF
--- a/demo-edit-es-module/module/package.json
+++ b/demo-edit-es-module/module/package.json
@@ -14,6 +14,12 @@
       "default": "./src/diffEngine.mjs"
     }
   },
+  "typesVersions": {
+    "*": {
+      "index": ["./editor.d.ts"],
+      "engine": ["./diff.d.ts"]
+    }
+  },
   "files": [
     "editor.d.ts",
     "./src/editor.js", "./src/worker.js", "./src/loader.js",


### PR DESCRIPTION
This change is required to correctly export types for older versions of TypeScript