### PR TITLE
Add fonts to Theme type

### DIFF
--- a/demo-edit-es-module/module/editor.d.ts
+++ b/demo-edit-es-module/module/editor.d.ts
@@ -202,17 +202,24 @@ export const enum ThemeColor {
 
 export type BaseTheme = 'dark' | 'light' | 'darcula';
 
+export type Font = {
+  size: string,
+  family: string,
+  weight: string
+}
+
+type WithFonts = {
+  uiFont: Font,
+  editorFont: Font
+}
+
 export type Theme = {
   [color in ThemeColor]?: string;
 } & {
   baseTheme: BaseTheme;
-} | BaseTheme;
+} & WithFonts | BaseTheme;
 
 export interface HasTheme {
-  setFontFamily(fontFamily: string): void,
-
-  setFontSize(fontSize: number): void,
-
   setTheme(theme: Theme): void
 }
 

--- a/demo-edit-es-module/module/editor.d.ts
+++ b/demo-edit-es-module/module/editor.d.ts
@@ -203,9 +203,9 @@ export const enum ThemeColor {
 export type BaseTheme = 'dark' | 'light' | 'darcula';
 
 export type Font = {
-  size: string,
+  size: number,
   family: string,
-  weight: string
+  weight: number
 }
 
 type WithFonts = {


### PR DESCRIPTION
Usage: https://devcloud-g.ru-northwest-201-dev.huaweicloud.com/codehub/project/758dee1d02064ae8a8766d2933eca0e1/codehub/675320/15/mergedetail?source=mprotasov%2Ftheme-font&target=master

Example:
`{"0":"#181818","1":"#cccccc","2":"#04395e","3":"#ffffff","4":"#2a2d2e","5":"#37373d","6":"#73c991","7":"#c74e39","8":"#e2c08d","9":"#181818","10":"#cccccc","11":"#1f1f1f","12":"#cccccc","13":"#282828","15":"#ff000033","16":"#ff000033","17":"#9bb95533","18":"#9ccc2c33","19":"#6e7681","20":"#c6c6c6","21":"#cccccc","baseTheme":"dark","editorFont":{"family":"Consolas, 'Courier New', monospace","size":14,"weight":400},"uiFont":{"family":"\"Segoe WPC\", \"Segoe UI\", sans-serif","size":13,"weight":400}}`